### PR TITLE
feat: user registration metainfo producer 생성

### DIFF
--- a/src/main/java/com/suite/suite_user_service/member/kafka/producer/SuiteUserProducer.java
+++ b/src/main/java/com/suite/suite_user_service/member/kafka/producer/SuiteUserProducer.java
@@ -3,7 +3,6 @@ package com.suite.suite_user_service.member.kafka.producer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.json.simple.JSONObject;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 
@@ -16,10 +15,18 @@ public class SuiteUserProducer {
 
     private final KafkaTemplate<String, String> kafkaTemplate;
 
-    public void sendMessage(String topic, Object data) {
+    public void userRegistrationFCMProducer(String topic, Object data) {
         log.info("User-Registration-FCM message : {}", data);
         JSONObject obj = new JSONObject();
         obj.put("uuid", "UserRegistrationProducer/" + Instant.now().toEpochMilli());
+        obj.put("data", data);
+        this.kafkaTemplate.send(topic, obj.toJSONString());
+    }
+
+    public void userRegistrationMetaInfoProducer(String topic, Object data) {
+        log.info("User-Registration-UserMetaInfo message : {}", data);
+        JSONObject obj = new JSONObject();
+        obj.put("uuid", "userRegistrationMetaInfoProducer/" + Instant.now().toEpochMilli());
         obj.put("data", data);
         this.kafkaTemplate.send(topic, obj.toJSONString());
     }

--- a/src/main/java/com/suite/suite_user_service/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/suite/suite_user_service/member/service/MemberServiceImpl.java
@@ -18,7 +18,6 @@ import com.suite.suite_user_service.member.repository.RefreshTokenRepository;
 import com.suite.suite_user_service.member.security.JwtCreator;
 import com.suite.suite_user_service.member.security.dto.AuthorizerDto;
 import lombok.RequiredArgsConstructor;
-import org.json.simple.JSONObject;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -31,7 +30,6 @@ import software.amazon.awssdk.services.sns.model.PublishResponse;
 import java.io.File;
 import java.io.IOException;
 import java.security.SecureRandom;
-import java.time.Instant;
 import java.util.*;
 
 
@@ -103,7 +101,9 @@ public class MemberServiceImpl implements MemberService {
         Map<String, Object> map = new HashMap<>();
         map.put("memberId", member.getMemberId());
         map.put("fcm", reqSignUpMemberDto.getFcmToken());
-        suiteUserProducer.sendMessage(USER_REGISTRATION_FCM, map);
+        map.put("accountStatus", member.getAccountStatus());
+        suiteUserProducer.userRegistrationFCMProducer(USER_REGISTRATION_FCM, map);
+        suiteUserProducer.userRegistrationMetaInfoProducer(USER_REGISTRATION_USERMETAINFO, map);
         return map;
     }
 


### PR DESCRIPTION
## 2023-09-25

### Target

블록체인 서비스에 회원가입시 meta 정보를 프로듀싱하는 KafkaProducer 추가. 

### Issue

전달하는 map 에서 member.getAccountStatus 만 추가하면 되는거라 FCM 프로듀서에 제공하는 data인 map 에 추가해서 보냈음.
FCM을 처리하는 컨슈머에서는 해당 데이터를 무시하면 돼서 일단 map에 단순하게 추가했는데 괜찮은지 확인부탁드립니다.